### PR TITLE
Fixes the build on gcc 6.x

### DIFF
--- a/main.h
+++ b/main.h
@@ -89,7 +89,7 @@
 #   define  LOGLEVEL_OK 7
 #   define  LOGI(...)  { nvprintfLevel(0, __VA_ARGS__); }
 #   define  LOGW(...)  { nvprintfLevel(1, __VA_ARGS__); }
-#   define  LOGE(...)  { nvprintfLevel(2, __FILE__"("S__LINE__"): **ERROR**:\n"__VA_ARGS__); }
+#   define  LOGE(...)  { nvprintfLevel(2, __FILE__ "(" S__LINE__ "): **ERROR**:\n" __VA_ARGS__); }
 #   define  LOGOK(...)  { nvprintfLevel(7, __VA_ARGS__); }
 
 #if _MSC_VER


### PR DESCRIPTION
The `LOGE` macro needed spaces ("C++11 requires a space between literal and string macro")
