### PR TITLE
Add aarch64 platform support in NvFoundation.h

### DIFF
--- a/NvFoundation.h
+++ b/NvFoundation.h
@@ -159,7 +159,7 @@ Platform define
 #   ifdef __CELLOS_LV2__
 #    define NV_PS3
 #        define NV_VMX
-#   elif defined(__arm__)
+#   elif defined(__arm__) || defined(__aarch64__)
 #        define NV_ARM
 #        if defined(__SNC__)
 #            define NV_PSP2


### PR DESCRIPTION
This fixes below error while compiling gl_vk_chopper on Jetson:

[ 13%] Building CXX object shared_sources/CMakeFiles/shared_sources.dir/nv_helpers/profiler.cpp.o
In file included from /home/nvidia/vulkan_nv/gl_vk_chopper/../shared_sources/platform.h:26:0,
                 from /home/nvidia/vulkan_nv/gl_vk_chopper/../shared_sources/main.h:31,
                 from /home/nvidia/vulkan_nv/shared_sources/nv_helpers_gl/GLSLProgram.cpp:16:
/home/nvidia/vulkan_nv/gl_vk_chopper/../shared_sources/NvFoundation.h:186:6: error: #error "Unknown platform"