### PR TITLE
VkMemoryRequirements2 sType must be STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2

### DIFF
--- a/nvvk/raytraceNV_vk.hpp
+++ b/nvvk/raytraceNV_vk.hpp
@@ -325,7 +325,7 @@ struct RaytracingBuilderNV
     memoryRequirementsInfo.type                  = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV;
     memoryRequirementsInfo.accelerationStructure = m_tlas.as.accel;
 
-    VkMemoryRequirements2 reqMem;
+    VkMemoryRequirements2 reqMem{VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2};
     vkGetAccelerationStructureMemoryRequirementsNV(m_device, &memoryRequirementsInfo, &reqMem);
     VkDeviceSize scratchSize = reqMem.memoryRequirements.size;
 
@@ -397,7 +397,7 @@ struct RaytracingBuilderNV
     memoryRequirementsInfo.type                  = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV;
     memoryRequirementsInfo.accelerationStructure = m_tlas.as.accel;
 
-    VkMemoryRequirements2 reqMem;
+    VkMemoryRequirements2 reqMem{VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2};
     vkGetAccelerationStructureMemoryRequirementsNV(m_device, &memoryRequirementsInfo, &reqMem);
     VkDeviceSize scratchSize = reqMem.memoryRequirements.size;
 
@@ -445,7 +445,7 @@ struct RaytracingBuilderNV
     memoryRequirementsInfo.type                  = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV;
     memoryRequirementsInfo.accelerationStructure = blas.as.accel;
 
-    VkMemoryRequirements2 reqMem;
+    VkMemoryRequirements2 reqMem{VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2};
     vkGetAccelerationStructureMemoryRequirementsNV(m_device, &memoryRequirementsInfo, &reqMem);
     VkDeviceSize scratchSize = reqMem.memoryRequirements.size;
 

--- a/nvvk/raytraceNV_vk.hpp
+++ b/nvvk/raytraceNV_vk.hpp
@@ -167,7 +167,7 @@ struct RaytracingBuilderNV
       memoryRequirementsInfo.accelerationStructure = blas.as.accel;
 
 
-      VkMemoryRequirements2 reqMem;
+      VkMemoryRequirements2 reqMem{VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2};
       vkGetAccelerationStructureMemoryRequirementsNV(m_device, &memoryRequirementsInfo, &reqMem);
       VkDeviceSize scratchSize = reqMem.memoryRequirements.size;
 


### PR DESCRIPTION
VkMemoryRequirements2 structure reqMem does not currently set sType to VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2.
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkMemoryRequirements2-sType-sType

VkMemoryRequirements2 structure reqMem does not currently set pNext to NULL or to a valid instance of VkMemoryDedicatedRequirements.
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkMemoryRequirements2-pNext-pNext