### PR TITLE
back_inserter is defined in <iterator>

### DIFF
--- a/nvvk/pipeline_vk.hpp
+++ b/nvvk/pipeline_vk.hpp
@@ -29,6 +29,7 @@
 
 #include <cassert>
 #include <string>
+#include <iterator>
 #include <vector>
 #include <vulkan/vulkan.h>
 


### PR DESCRIPTION
Windows 10 build failed:
shared_sources\nvvk\pipeline_vk.hpp(508,46): error C2039: 'back_inserter': is not a member of 'std'

Adding iterator fixed the problem:
http://cplusplus.com/reference/iterator/back_inserter/
