### PR TITLE
Add missing include in imgui_helper.h (<limits>)

### DIFF
--- a/imgui/imgui_helper.h
+++ b/imgui/imgui_helper.h
@@ -30,6 +30,7 @@
 #include <nvpwindow.hpp>
 
 #include <algorithm>
+#include <limits>
 #include <array>
 #include <climits>
 #include <functional>


### PR DESCRIPTION
required for `std::limits<...>::max()`