### PR TITLE
fix: error msg not match if condition

### DIFF
--- a/nvvk/raytraceKHR_vk.hpp
+++ b/nvvk/raytraceKHR_vk.hpp
@@ -214,5 +214,5 @@ private:
 }  // namespace nvvk
 
 #else
-#error This include requires VK_KHR_ray_tracing support in the Vulkan SDK.
+#error This include requires VK_KHR_acceleration_structure support in the Vulkan SDK.
 #endif


### PR DESCRIPTION
fix: error msg not match if condition,  VK_KHR_acceleration_structure vs VK_KHR_ray_tracing

```
#if **VK_KHR_acceleration_structure**
...
#else
    #error This include requires **VK_KHR_ray_tracing** support in the Vulkan SDK.
...
```