### PR TITLE
set VK_SDK_PATH only if existing

### DIFF
--- a/nvvk/extensions_vk.py
+++ b/nvvk/extensions_vk.py
@@ -139,14 +139,17 @@ def get_function(rtype, name, params):
 if __name__ == "__main__":
     # Using incoming argument, local XML or web version
     specpath = "https://raw.githubusercontent.com/KhronosGroup/Vulkan-Docs/main/xml/vk.xml"
-    loc_spec_path = os.path.normpath(os.getenv('VK_SDK_PATH') + '/share/vulkan/registry/vk.xml')
+    vk_sdk_path = os.getenv('VK_SDK_PATH')
+
+    if vk_sdk_path:
+        loc_spec_path = os.path.normpath(vk_sdk_path + '/share/vulkan/registry/vk.xml')
+
+        if os.path.isfile(loc_spec_path):
+            specpath = loc_spec_path
 
     parser = argparse.ArgumentParser(description='Generates entry points for Vulkan extensions in extensions_vk.cpp.')
     parser.add_argument('--beta', action='store_true', help='Includes provisional Vulkan extensions; these extensions are not guaranteed to be consistent across Vulkan SDK versions.')
     parser.add_argument('spec', type=str, nargs='?', help='Optional path to a vk.xml file to use to generate extensions. Otherwise, uses the vk.xml in the Vulkan SDK distribution specified in the VK_SDK_PATH environment variable.')
-
-    if os.path.isfile(loc_spec_path):
-      specpath = loc_spec_path
 
     args = parser.parse_args()
     if args.spec is not None:


### PR DESCRIPTION
When running extensions_vk.py --beta python report:

File "/home/marcin/dev/nvpro_samples/nvpro_core/nvvk/extensions_vk.py", line 142, in loc_spec_path = os.path.normpath(os.getenv('VK_SDK_PATH') + '/share/vulkan/registry/vk.xml') ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

As @NeilBickford-NV  explain this is due to evaluating env to None. This code only modifying patch when env set and the file exist