### PR TITLE
explicit include the cstdint header for gcc 13 support

### DIFF
--- a/nvh/shaderfilemanager.hpp
+++ b/nvh/shaderfilemanager.hpp
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace nvh {
 


### PR DESCRIPTION
According to the https://gcc.gnu.org/gcc-13/porting_to.html, gcc 13 doesn't implicitly include `<cstdint>` anymore, so we need to include it explicitly.

Related to [PR](https://github.com/nvpro-samples/vk_raytracing_tutorial_KHR/pull/61) in [vk_raytracing_tutorial_KHR](https://github.com/nvpro-samples/vk_raytracing_tutorial_KHR)