### PR TITLE
Fix failed assertion when running in MSVC debug mode

### DIFF
--- a/imgui/imgui_helper.cpp
+++ b/imgui/imgui_helper.cpp
@@ -550,7 +550,7 @@ void Panel::Begin(Side side /*= Side::Right*/, float alpha /*= 0.5f*/, char* nam
   ImGui::SetNextWindowViewport(viewport->ID);
 
   // All flags to dummy window
-  ImGuiWindowFlags host_window_flags;
+  ImGuiWindowFlags host_window_flags{};
   host_window_flags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize;
   host_window_flags |= ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDocking;
   host_window_flags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;


### PR DESCRIPTION
The flags created in `Panel::Begin()` are not initialized to zero, causing MSVC to initialize them to 0xCCCCCCCC by default. `ImGuiWindowFlags_NavFlattened` happens to be set to 1 due to this, which causes [an assertion](https://github.com/nvpro-samples/nvpro_core/blob/master/third_party/imgui/imgui.cpp#L6889) to fail.