### PR TITLE
Fix linux build

### DIFF
--- a/cmake/setup.cmake
+++ b/cmake/setup.cmake
@@ -1054,6 +1054,7 @@ macro(_process_shared_cmake_code)
   )
    
   if(UNIX)
+    LIST(APPEND PLATFORM_LIBRARIES "tbb")
     LIST(APPEND PLATFORM_LIBRARIES "Xxf86vm")
 
 	#Work around some obscure bug where samples would crash in std::filesystem::~path() when


### PR DESCRIPTION
It looks like somewhere deep inside std:vector tbb is being used. However library was not added and linker was failing to find this library definitions.

Tested on:
GCC 14.2.1 20240910
6.11.6-zen1-1-zen 