### PR TITLE
Fix first `vkCmdPipelineBarrier` in `buildTlas`'s command buffer

### DIFF
--- a/nvvk/raytraceKHR_vk.hpp
+++ b/nvvk/raytraceKHR_vk.hpp
@@ -157,7 +157,7 @@ public:
     VkMemoryBarrier barrier{VK_STRUCTURE_TYPE_MEMORY_BARRIER};
     barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
-    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
                          VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 1, &barrier, 0, nullptr, 0, nullptr);
 
     // Creating the TLAS


### PR DESCRIPTION
# Simplified structure of faulty command buffer:
![buildTlas command buffer](https://github.com/user-attachments/assets/168057e6-c174-4cea-a8bf-23c3d0ea34bf)

`vkCmdPipelineBarrier` is set to synchronize `VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR` operations, both before and after this barrier (`srcStageMask` and `dstStageMask`).

However, [Vulkan specification](https://registry.khronos.org/vulkan/specs/latest/man/html/VkPipelineStageFlagBits.html#_description) states that `vkCmdCopyBuffer` is executed in pipeline stage covered by `VK_PIPELINE_STAGE_TRANSFER_BIT`,
which means that this `vkCmdPipelineBarrier` is not guaranteed to synchronize a `vkCmdCopyBuffer` operation,
as `srcStageMask` argument is instead set to `VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR`.

# To summarize:
Argument `srcStageMask` in `vkCmdPipelineBarrier` is incorrectly set to
`VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR`, when it should be set to `VK_PIPELINE_STAGE_TRANSFER_BIT`
in order to guarantee synchronization of `vkCmdCopyBuffer`.